### PR TITLE
max_rows is required so put it back in

### DIFF
--- a/src/GBQ.jl
+++ b/src/GBQ.jl
@@ -65,8 +65,8 @@ end
 # Execute a query 
 #
 # Returns a dataframe
-function gbq_query(query; use_legacy_sql=false, quiet=true)
-  response = JSON.parse(readstring(`bq --format=json  --quiet="$quiet" query --use_legacy_sql="$use_legacy_sql" "$query"`))
+function gbq_query(query; use_legacy_sql=false, quiet=true, max_rows=100000000)
+  response = JSON.parse(readstring(`bq --format=json  --quiet="$quiet" query --use_legacy_sql="$use_legacy_sql" --max_rows="$max_rows" "$query"`))
   return _gbq_parse(response)
 end
 


### PR DESCRIPTION
I removed max_rows without realizing the bq cli would default to 100. I've put it back in as a kwarg with a very high number by default.